### PR TITLE
fix: RSS-ECOMM-4_17 Display two prices after promo code application in cart

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -52,6 +52,7 @@ export default class App {
     document.addEventListener('DOMContentLoaded', async () => {
       await AuthService.sessionStateHandler();
       if (CurrentCart.id) {
+        await CartService.updateDiscountCodes();
         await CartService.updateCart(CurrentCart.id);
         this.headerController.setCartCount(CurrentCart.totalCount);
       }

--- a/src/app/components/cart/cart-view.ts
+++ b/src/app/components/cart/cart-view.ts
@@ -189,6 +189,7 @@ export default class CartView extends BaseComponent {
       let fullPrice;
       const resultPrice = this.cart?.totalPrice.centAmount;
       const discountedPrice = this.cart?.discountOnTotalPrice?.discountedAmount.centAmount;
+
       if (resultPrice && discountedPrice) {
         fullPrice = resultPrice + discountedPrice;
         this.totalSum?.getChildren[1].setTextContent('');
@@ -198,8 +199,13 @@ export default class CartView extends BaseComponent {
         ]);
       } else if (CartService.isClassicCroissantInCart() && CartService.isDOUBLECodeApplied()) {
         this.totalSum?.getChildren[1].setTextContent('');
+
+        const croissantPrice =
+          (CurrentCart.products.find((product) => product.productKey === 'classic-croissant')
+            ?.discountedPricePerQuantity[0].quantity ?? 0) * 270;
+
         this.totalSum?.getChildren[1].appendChildren([
-          span([styles.full_price], setPrice((resultPrice as number) * 2)),
+          span([styles.full_price], setPrice((resultPrice as number) + croissantPrice)),
           span([styles.discounted_price], setPrice(resultPrice)),
         ]);
       }

--- a/src/app/services/cart-service/cart-service.ts
+++ b/src/app/services/cart-service/cart-service.ts
@@ -11,7 +11,6 @@ class CartApiService {
 
   constructor() {
     CurrentCart.setCart(JSON.parse(localStorage.getItem('cartNetN') as string) || null);
-    this.getDiscountCodes();
   }
 
   public async createNewCustomerCart(ID: Customer['id']) {
@@ -91,7 +90,7 @@ class CartApiService {
     }
   }
 
-  private async getDiscountCodes() {
+  public async updateDiscountCodes() {
     try {
       const response = await AuthService.getRoot().discountCodes().get().execute();
       const discountCodes = response.body.results;


### PR DESCRIPTION
## Type of PR
- [ ] Feature ⭐
- [x] Bug Fix ✔️
- [ ] Refactor 🔨
- [ ] Documentation Update 📝
- [ ] Environment Set Up ⚙️
- [ ] Other ❓

## Description of the changes
Fix full price when promo DOUBLE is applied and classic croissants are in cart

## Related Tickets & Documents
- https://github.com/misterT1A/eCommerce-Application/issues/200

## Screenshots
![image](https://github.com/misterT1A/eCommerce-Application/assets/121252461/12029f49-7ef3-439f-a7bd-40253a214311)

